### PR TITLE
Allow IndexedRelationshipExpander to expand relationships from the key value end of the IndexedRelationship

### DIFF
--- a/src/main/java/org/neo4j/collections/sortedtree/NodeEntry.java
+++ b/src/main/java/org/neo4j/collections/sortedtree/NodeEntry.java
@@ -30,10 +30,10 @@ import org.neo4j.collections.sortedtree.SortedTree.RelTypes;
 class NodeEntry
 {
 	static final String NODE_ID = "node_id";
-	
+
 	private Relationship entryRelationship;
 	private TreeNode treeNode;
-	
+
 	NodeEntry( TreeNode treeNode, Relationship underlyingRelationship )
 	{
 		assert treeNode != null;
@@ -41,49 +41,49 @@ class NodeEntry
 		this.treeNode = treeNode;
 		this.entryRelationship = underlyingRelationship;
 	}
-	
+
 	Relationship getUnderlyingRelationship()
 	{
 		return entryRelationship;
 	}
-	
+
 	TreeNode getTreeNode()
 	{
 		return treeNode;
 	}
-	
+
 	private SortedTree getBTree()
 	{
 		return treeNode.getBTree();
 	}
-	
+
 	TreeNode getBeforeSubTree()
 	{
-		Relationship subTreeRel = getStartNode().getSingleRelationship( 
+		Relationship subTreeRel = getStartNode().getSingleRelationship(
 			RelTypes.SUB_TREE, Direction.OUTGOING );
 		if ( subTreeRel != null )
 		{
-			return new TreeNode( getBTree(), 
+			return new TreeNode( getBTree(),
 				subTreeRel.getEndNode() );
 		}
 		return null;
 	}
-	
+
 	TreeNode getAfterSubTree()
 	{
-		Relationship subTreeRel = getEndNode().getSingleRelationship( 
+		Relationship subTreeRel = getEndNode().getSingleRelationship(
 			RelTypes.SUB_TREE, Direction.OUTGOING );
 		if ( subTreeRel != null )
 		{
-			return new TreeNode( getBTree(), 
+			return new TreeNode( getBTree(),
 				subTreeRel.getEndNode() );
 		}
 		return null;
 	}
-	
+
 	NodeEntry getNextKey()
 	{
-		Relationship nextKeyRel = getEndNode().getSingleRelationship( 
+		Relationship nextKeyRel = getEndNode().getSingleRelationship(
 			RelTypes.KEY_ENTRY, Direction.OUTGOING );
 		if ( nextKeyRel != null )
 		{
@@ -91,10 +91,10 @@ class NodeEntry
 		}
 		return null;
 	}
-	
+
 	NodeEntry getPreviousKey()
 	{
-		Relationship prevKeyRel = getStartNode().getSingleRelationship( 
+		Relationship prevKeyRel = getStartNode().getSingleRelationship(
 			RelTypes.KEY_ENTRY, Direction.INCOMING );
 		if ( prevKeyRel != null )
 		{
@@ -109,16 +109,16 @@ class NodeEntry
         treeNode.removeEntry( this.getTheNode() );
 	}
 */
-    
+
 	@Override
 	public String toString()
 	{
 		return "Entry[" + getNodes() + "]";
 	}
-	
+
 	boolean isLeaf()
 	{
-		if ( getUnderlyingRelationship().getStartNode().getSingleRelationship( 
+		if ( getUnderlyingRelationship().getStartNode().getSingleRelationship(
 			RelTypes.SUB_TREE, Direction.OUTGOING ) != null )
 		{
 			assert getUnderlyingRelationship().getEndNode().
@@ -126,11 +126,11 @@ class NodeEntry
 				!= null;
 			return false;
 		}
-		assert getUnderlyingRelationship().getEndNode().getSingleRelationship( 
+		assert getUnderlyingRelationship().getEndNode().getSingleRelationship(
 			RelTypes.SUB_TREE, Direction.OUTGOING ) == null;
 		return true;
 	}
-	
+
 	Node getANode()
 	{
 			Iterable<Relationship> rels = getEndNode().getRelationships(RelTypes.KEY_VALUE, Direction.OUTGOING);
@@ -139,11 +139,11 @@ class NodeEntry
 			}
 			throw new RuntimeException("Key entry is empty");
 	}
-	
+
 	class NodeIterator implements Iterator<Node>{
-		
+
 		Iterator<Relationship> rels;
-		
+
 		NodeIterator(Iterator<Relationship> rels){
 			this.rels = rels;
 		}
@@ -171,18 +171,32 @@ class NodeEntry
 			Iterable<Relationship> rels = getEndNode().getRelationships(RelTypes.KEY_VALUE, Direction.OUTGOING);
 			return new NodeIterator(rels.iterator());
 		}
-		
+
 	}
-	
+
     Iterable<Node> getNodes()
     {
     	return new NodeIterable();
-    	
-    	
+
+
 //        return getBTree().getGraphDb().getNodeById( 
 //            (Long) getUnderlyingRelationship().getProperty( NODE_ID ) ); 
     }
-    
+
+	class RelationshipIterable implements Iterable<Relationship>{
+
+		@Override
+		public Iterator<Relationship> iterator() {
+            return getEndNode().getRelationships(RelTypes.KEY_VALUE, Direction.OUTGOING).iterator();
+		}
+
+	}
+
+    Iterable<Relationship> getRelationships()
+    {
+    	return new RelationshipIterable();
+    }
+
     void setNode( Node node )
     {
     	Relationship rel = getEndNode().createRelationshipTo(node, RelTypes.KEY_VALUE);
@@ -191,13 +205,13 @@ class NodeEntry
     		rel.setProperty(SortedTree.TREE_NAME, treeName);
     	}
     }
-    
-    
+
+
 	Node getStartNode()
 	{
 		return entryRelationship.getStartNode();
 	}
-	
+
 	Node getEndNode()
 	{
 		return entryRelationship.getEndNode();
@@ -213,10 +227,10 @@ class NodeEntry
 			rel.delete();
 		}
 		entryRelationship.delete();
-		entryRelationship = startNode.createRelationshipTo( endNode, 
+		entryRelationship = startNode.createRelationshipTo( endNode,
 			RelTypes.KEY_ENTRY );
 		for(TempRelationship trl: trls){
-			Relationship rel = getEndNode().createRelationshipTo(trl.getEndNode(), RelTypes.KEY_VALUE);	
+			Relationship rel = getEndNode().createRelationshipTo(trl.getEndNode(), RelTypes.KEY_VALUE);
 			for(String key: trl.getProperties().keySet()){
 				rel.setProperty(key, trl.getProperties().get(key));
 			}

--- a/src/test/java/org/neo4j/collections/indexedrelationship/TestIndexedRelationship.java
+++ b/src/test/java/org/neo4j/collections/indexedrelationship/TestIndexedRelationship.java
@@ -19,130 +19,261 @@
  */
 package org.neo4j.collections.indexedrelationship;
 
-import static org.junit.Assert.assertTrue;
-
-import java.util.Comparator;
-
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
+import org.neo4j.collections.Neo4jTestCase;
 import org.neo4j.graphdb.Direction;
-import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.RelationshipType;
-import org.neo4j.collections.Neo4jTestCase;
+
+import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class TestIndexedRelationship extends Neo4jTestCase
 {
-	public static class IdComparator implements java.util.Comparator<Node>{
-		public int compare(Node n1, Node n2){
-			long l1 = Long.reverse(n1.getId());
-			long l2 = Long.reverse(n2.getId());
-			if(l1 == l2) return 0;
-			else if(l1 < l2) return -1;
-			else return 1;
-		}
-	}
-	
-	static enum RelTypes implements RelationshipType
-	{
-		DIRECT_RELATIONSHIP,
-		INDEXED_RELATIONSHIP,
-		INDEXED_RELATIONSHIP_TWO
-	}
+    public static class IdComparator implements java.util.Comparator<Node>
+    {
+        public int compare( Node n1, Node n2 )
+        {
+            long l1 = Long.reverse( n1.getId() );
+            long l2 = Long.reverse( n2.getId() );
+            if ( l1 == l2 )
+            {
+                return 0;
+            }
+            else if ( l1 < l2 )
+            {
+                return -1;
+            }
+            else
+            {
+                return 1;
+            }
+        }
+    }
 
-	@Test
-	public void testIndexRelationshipBasic()
-	{
-		Node indexedNode = graphDb().createNode();
-		IndexedRelationship ir = new IndexedRelationship(RelTypes.INDEXED_RELATIONSHIP, Direction.OUTGOING, new IdComparator(), true, indexedNode, graphDb());
-		
-		Node n1 = graphDb().createNode();
-		n1.setProperty("name", "n1");
-		Node n2 = graphDb().createNode();
-		n2.setProperty("name", "n2");
-		Node n3 = graphDb().createNode();
-		n3.setProperty("name", "n3");
-		Node n4 = graphDb().createNode();
-		n4.setProperty("name", "n4");
-		
-		indexedNode.createRelationshipTo(n1, RelTypes.DIRECT_RELATIONSHIP);
-		indexedNode.createRelationshipTo(n3, RelTypes.DIRECT_RELATIONSHIP);
-		ir.createRelationshipTo(n2);
-		ir.createRelationshipTo(n4);
-		
-		IndexedRelationshipExpander re1 = new IndexedRelationshipExpander(graphDb(), Direction.OUTGOING, RelTypes.DIRECT_RELATIONSHIP);
-		IndexedRelationshipExpander re2 = new IndexedRelationshipExpander(graphDb(), Direction.OUTGOING, RelTypes.INDEXED_RELATIONSHIP);
-		
-		int count = 0;
-		for(Relationship rel: re1.expand(indexedNode)){
-			if(count == 0){
-				assertTrue( rel.getEndNode().equals(n1) || rel.getEndNode().equals(n3));
-			}
-			if(count == 1){
-				assertTrue( rel.getEndNode().equals(n1) || rel.getEndNode().equals(n3));
-			}
-			count++;
-		}
-		assertTrue(count == 2);
-		count = 0;
-		for(Relationship rel: re2.expand(indexedNode)){
-			if(count == 0){
-				assertTrue( rel.getEndNode().equals(n2) );
-			}
-			if(count == 1){
-				assertTrue( rel.getEndNode().equals(n4) );
-			}
-			count++;
-		}
-		assertTrue(count == 2);
-	}
+    public static enum RelTypes implements RelationshipType
+    {
+        DIRECT_RELATIONSHIP,
+        INDEXED_RELATIONSHIP,
+        INDEXED_RELATIONSHIP_TWO
+    }
 
     @Test
-    public void testTwoIndexRelationshipsOnSingleNode() {
+    public void testIndexRelationshipBasic()
+    {
         Node indexedNode = graphDb().createNode();
-        IndexedRelationship ir = new IndexedRelationship(RelTypes.INDEXED_RELATIONSHIP, Direction.OUTGOING, new IdComparator(), true, indexedNode, graphDb());
-        IndexedRelationship ir2 = new IndexedRelationship(RelTypes.INDEXED_RELATIONSHIP_TWO, Direction.OUTGOING, new IdComparator(), true, indexedNode, graphDb());
+        IndexedRelationship ir = new IndexedRelationship( RelTypes.INDEXED_RELATIONSHIP, Direction.OUTGOING,
+            new IdComparator(), true, indexedNode, graphDb() );
 
         Node n1 = graphDb().createNode();
-        n1.setProperty("name", "n1");
+        n1.setProperty( "name", "n1" );
         Node n2 = graphDb().createNode();
-        n2.setProperty("name", "n2");
+        n2.setProperty( "name", "n2" );
         Node n3 = graphDb().createNode();
-        n3.setProperty("name", "n3");
+        n3.setProperty( "name", "n3" );
         Node n4 = graphDb().createNode();
-        n4.setProperty("name", "n4");
+        n4.setProperty( "name", "n4" );
 
-        ir.createRelationshipTo(n2);
-        ir.createRelationshipTo(n4);
-        ir2.createRelationshipTo(n1);
-        ir2.createRelationshipTo(n3);
-		
-        IndexedRelationshipExpander re1 = new IndexedRelationshipExpander(graphDb(), Direction.OUTGOING, RelTypes.INDEXED_RELATIONSHIP_TWO);
-        IndexedRelationshipExpander re2 = new IndexedRelationshipExpander(graphDb(), Direction.OUTGOING, RelTypes.INDEXED_RELATIONSHIP);
+        indexedNode.createRelationshipTo( n1, RelTypes.DIRECT_RELATIONSHIP );
+        indexedNode.createRelationshipTo( n3, RelTypes.DIRECT_RELATIONSHIP );
+        ir.createRelationshipTo( n2 );
+        ir.createRelationshipTo( n4 );
+
+        IndexedRelationshipExpander re1 = new IndexedRelationshipExpander( graphDb(), Direction.OUTGOING,
+            RelTypes.DIRECT_RELATIONSHIP );
+        IndexedRelationshipExpander re2 = new IndexedRelationshipExpander( graphDb(), Direction.OUTGOING,
+            RelTypes.INDEXED_RELATIONSHIP );
 
         int count = 0;
-        for(Relationship rel: re1.expand(indexedNode)){
-            if(count == 0){
-                assertTrue( rel.getEndNode().equals(n1) || rel.getEndNode().equals(n3));
-            }
-            if(count == 1){
-                assertTrue( rel.getEndNode().equals(n1) || rel.getEndNode().equals(n3));
-            }
+        for ( Relationship rel : re1.expand( indexedNode ) )
+        {
+            assertTrue( rel.getEndNode().equals( n1 ) || rel.getEndNode().equals( n3 ) );
+            assertEquals( indexedNode, rel.getStartNode() );
             count++;
         }
-        assertTrue(count == 2);
+        assertEquals( 2, count );
+
         count = 0;
-        for(Relationship rel: re2.expand(indexedNode)){
-            if(count == 0){
-                assertTrue( rel.getEndNode().equals(n2) );
+        for ( Relationship rel : re2.expand( indexedNode ) )
+        {
+            if ( count == 0 )
+            {
+                assertEquals( n2, rel.getEndNode() );
             }
-            if(count == 1){
-                assertTrue( rel.getEndNode().equals(n4) );
+            if ( count == 1 )
+            {
+                assertEquals( n4, rel.getEndNode() );
             }
+            assertEquals( indexedNode, rel.getStartNode() );
             count++;
         }
-        assertTrue(count == 2);
+        assertEquals( 2, count );
+    }
+
+    @Test
+    public void testIndexRelationshipIncoming()
+    {
+        Node indexedNode = graphDb().createNode();
+        IndexedRelationship ir = new IndexedRelationship( RelTypes.INDEXED_RELATIONSHIP, Direction.INCOMING,
+            new IdComparator(), true, indexedNode, graphDb() );
+
+        Node n1 = graphDb().createNode();
+        n1.setProperty( "name", "n1" );
+        Node n2 = graphDb().createNode();
+        n2.setProperty( "name", "n2" );
+        Node n3 = graphDb().createNode();
+        n3.setProperty( "name", "n3" );
+        Node n4 = graphDb().createNode();
+        n4.setProperty( "name", "n4" );
+
+        n1.createRelationshipTo( indexedNode, RelTypes.DIRECT_RELATIONSHIP );
+        n3.createRelationshipTo( indexedNode, RelTypes.DIRECT_RELATIONSHIP );
+        ir.createRelationshipTo( n2 );
+        ir.createRelationshipTo( n4 );
+
+        IndexedRelationshipExpander re1 = new IndexedRelationshipExpander( graphDb(), Direction.INCOMING,
+            RelTypes.DIRECT_RELATIONSHIP );
+        IndexedRelationshipExpander re2 = new IndexedRelationshipExpander( graphDb(), Direction.INCOMING,
+            RelTypes.INDEXED_RELATIONSHIP );
+
+        int count = 0;
+        for ( Relationship rel : re1.expand( indexedNode ) )
+        {
+            assertTrue( rel.getStartNode().equals( n1 ) || rel.getStartNode().equals( n3 ) );
+            assertEquals( indexedNode, rel.getEndNode() );
+            count++;
+        }
+        assertEquals( 2, count );
+
+        count = 0;
+        for ( Relationship rel : re2.expand( indexedNode ) )
+        {
+            if ( count == 0 )
+            {
+                assertEquals( n2, rel.getStartNode() );
+            }
+            if ( count == 1 )
+            {
+                assertEquals( n4, rel.getStartNode() );
+            }
+            assertEquals( indexedNode, rel.getEndNode() );
+            count++;
+        }
+        assertEquals( 2, count );
+    }
+
+    @Test
+    public void testTwoIndexRelationshipsOnSingleNode()
+    {
+        Node indexedNode = graphDb().createNode();
+        IndexedRelationship ir = new IndexedRelationship( RelTypes.INDEXED_RELATIONSHIP, Direction.OUTGOING,
+            new IdComparator(), true, indexedNode, graphDb() );
+        IndexedRelationship ir2 = new IndexedRelationship( RelTypes.INDEXED_RELATIONSHIP_TWO, Direction.OUTGOING,
+            new IdComparator(), true, indexedNode, graphDb() );
+
+        Node n1 = graphDb().createNode();
+        n1.setProperty( "name", "n1" );
+        Node n2 = graphDb().createNode();
+        n2.setProperty( "name", "n2" );
+        Node n3 = graphDb().createNode();
+        n3.setProperty( "name", "n3" );
+        Node n4 = graphDb().createNode();
+        n4.setProperty( "name", "n4" );
+
+        ir.createRelationshipTo( n2 );
+        ir.createRelationshipTo( n4 );
+        ir2.createRelationshipTo( n1 );
+        ir2.createRelationshipTo( n3 );
+
+        IndexedRelationshipExpander re1 = new IndexedRelationshipExpander( graphDb(), Direction.OUTGOING,
+            RelTypes.INDEXED_RELATIONSHIP_TWO );
+        IndexedRelationshipExpander re2 = new IndexedRelationshipExpander( graphDb(), Direction.OUTGOING,
+            RelTypes.INDEXED_RELATIONSHIP );
+
+        int count = 0;
+        for ( Relationship rel : re1.expand( indexedNode ) )
+        {
+            assertTrue( rel.getEndNode().equals( n1 ) || rel.getEndNode().equals( n3 ) );
+            assertEquals( indexedNode, rel.getStartNode() );
+            count++;
+        }
+        assertEquals( 2, count );
+
+        count = 0;
+        for ( Relationship rel : re2.expand( indexedNode ) )
+        {
+            if ( count == 0 )
+            {
+                assertEquals( n2, rel.getEndNode() );
+            }
+            if ( count == 1 )
+            {
+                assertEquals( n4, rel.getEndNode() );
+            }
+            assertEquals( indexedNode, rel.getStartNode() );
+            count++;
+        }
+        assertEquals( 2, count );
+    }
+
+    @Test
+    public void testTwoIndexRelationshipsToSingleDestination()
+    {
+        Node indexedNode = graphDb().createNode();
+        IndexedRelationship ir = new IndexedRelationship( RelTypes.INDEXED_RELATIONSHIP, Direction.OUTGOING,
+            new IdComparator(), true, indexedNode, graphDb() );
+        Node indexedNode2 = graphDb().createNode();
+        IndexedRelationship ir2 = new IndexedRelationship( RelTypes.INDEXED_RELATIONSHIP, Direction.OUTGOING,
+            new IdComparator(), true, indexedNode2, graphDb() );
+
+        Node destination = graphDb().createNode();
+        destination.setProperty( "name", "n1" );
+
+        ir.createRelationshipTo( destination );
+        ir2.createRelationshipTo( destination );
+
+        IndexedRelationshipExpander relationshipExpander = new IndexedRelationshipExpander( graphDb(),
+            Direction.OUTGOING, RelTypes.INDEXED_RELATIONSHIP );
+
+        int count = 0;
+        for ( Relationship rel : relationshipExpander.expand( indexedNode ) )
+        {
+            assertEquals( destination, rel.getEndNode() );
+            assertEquals( indexedNode, rel.getStartNode() );
+            count++;
+        }
+        for ( Relationship rel : relationshipExpander.expand( indexedNode2 ) )
+        {
+            assertEquals( destination, rel.getEndNode() );
+            assertEquals( indexedNode2, rel.getStartNode() );
+            count++;
+        }
+        assertEquals( 2, count );
+    }
+
+    @Test
+    public void testIndexedRelationshipExpanderAtDestination()
+    {
+        Node indexedNode = graphDb().createNode();
+        Node nonIndexedNode = graphDb().createNode();
+        IndexedRelationship ir = new IndexedRelationship( RelTypes.INDEXED_RELATIONSHIP, Direction.OUTGOING,
+            new IdComparator(), true, indexedNode, graphDb() );
+
+        Node n1 = graphDb().createNode();
+        ir.createRelationshipTo( n1 );
+        nonIndexedNode.createRelationshipTo( n1, RelTypes.INDEXED_RELATIONSHIP );
+
+        IndexedRelationshipExpander relationshipExpander = new IndexedRelationshipExpander( graphDb(),
+            Direction.INCOMING, RelTypes.INDEXED_RELATIONSHIP );
+
+        int count = 0;
+        for ( Relationship rel : relationshipExpander.expand( n1 ) )
+        {
+            assertTrue( rel.getStartNode().equals( indexedNode ) || rel.getStartNode().equals( nonIndexedNode ) );
+            assertEquals( n1, rel.getEndNode() );
+            count++;
+        }
+        assertEquals( 2, count );
     }
 }

--- a/src/test/java/org/neo4j/collections/indexedrelationship/TestRelationshipProperties.java
+++ b/src/test/java/org/neo4j/collections/indexedrelationship/TestRelationshipProperties.java
@@ -1,0 +1,111 @@
+/**
+ * Copyright (c) 2002-2011 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.collections.indexedrelationship;
+
+import org.junit.Test;
+import org.neo4j.collections.Neo4jTestCase;
+import org.neo4j.graphdb.Direction;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Relationship;
+
+import static junit.framework.Assert.assertEquals;
+
+public class TestRelationshipProperties extends Neo4jTestCase
+{
+    @Test
+    public void testIndexRelationshipAttributes()
+    {
+        Node indexedNode = graphDb().createNode();
+        IndexedRelationship ir = new IndexedRelationship( TestIndexedRelationship.RelTypes.INDEXED_RELATIONSHIP,
+            Direction.OUTGOING, new TestIndexedRelationship.IdComparator(), true, indexedNode, graphDb() );
+
+        Node node1 = graphDb().createNode();
+        node1.setProperty( "name", "node 1" );
+        Node node2 = graphDb().createNode();
+        node2.setProperty( "name", "node 2" );
+
+        Relationship relationship1 = ir.createRelationshipTo( node1 );
+        relationship1.setProperty( "rel property", "relationship 1" );
+        Relationship relationship2 = ir.createRelationshipTo( node2 );
+        relationship2.setProperty( "rel property", "relationship 2" );
+
+        IndexedRelationshipExpander expander = new IndexedRelationshipExpander( graphDb(), Direction.OUTGOING,
+            TestIndexedRelationship.RelTypes.INDEXED_RELATIONSHIP );
+
+        int count = 0;
+        for ( Relationship rel : expander.expand( indexedNode ) )
+        {
+            if ( rel.getEndNode().equals( node1 ) )
+            {
+                assertEquals( rel.getProperty( "rel property" ), "relationship 1" );
+            }
+
+            if ( rel.getEndNode().equals( node2 ) )
+            {
+                assertEquals( rel.getProperty( "rel property" ), "relationship 2" );
+            }
+
+            count++;
+        }
+
+        assertEquals( 2, count );
+    }
+
+    @Test
+    public void testIndexRelationshipAttributesFromDestination()
+    {
+        Node indexedNode = graphDb().createNode();
+        IndexedRelationship ir = new IndexedRelationship( TestIndexedRelationship.RelTypes.INDEXED_RELATIONSHIP,
+            Direction.OUTGOING, new TestIndexedRelationship.IdComparator(), true, indexedNode, graphDb() );
+
+        Node indexedNode2 = graphDb().createNode();
+        IndexedRelationship ir2 = new IndexedRelationship( TestIndexedRelationship.RelTypes.INDEXED_RELATIONSHIP,
+            Direction.OUTGOING, new TestIndexedRelationship.IdComparator(), true, indexedNode2, graphDb() );
+
+        Node destination = graphDb().createNode();
+        destination.setProperty( "name", "node 1" );
+
+        Relationship relationship1 = ir.createRelationshipTo( destination );
+        relationship1.setProperty( "rel property", "relationship 1" );
+        Relationship relationship2 = ir2.createRelationshipTo( destination );
+        relationship2.setProperty( "rel property", "relationship 2" );
+
+        IndexedRelationshipExpander expander = new IndexedRelationshipExpander( graphDb(), Direction.INCOMING,
+            TestIndexedRelationship.RelTypes.INDEXED_RELATIONSHIP );
+
+        int count = 0;
+        for ( Relationship rel : expander.expand( destination ) )
+        {
+            if ( rel.getStartNode().equals( indexedNode ) )
+            {
+                assertEquals( rel.getProperty( "rel property" ), "relationship 1" );
+            }
+
+            if ( rel.getStartNode().equals( indexedNode2 ) )
+            {
+                assertEquals( rel.getProperty( "rel property" ), "relationship 2" );
+            }
+
+            count++;
+        }
+
+        assertEquals( 2, count );
+    }
+}

--- a/src/test/java/org/neo4j/collections/sortedtree/TestSortedTree.java
+++ b/src/test/java/org/neo4j/collections/sortedtree/TestSortedTree.java
@@ -19,19 +19,14 @@
  */
 package org.neo4j.collections.sortedtree;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.util.Iterator;
-import java.util.LinkedList;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.neo4j.graphdb.Node;
 import org.neo4j.collections.Neo4jTestCase;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Relationship;
+
+import static org.junit.Assert.assertTrue;
 
 public class TestSortedTree extends Neo4jTestCase
 {
@@ -205,7 +200,7 @@ public class TestSortedTree extends Neo4jTestCase
 
 		assertTrue( longTree.iterator().hasNext() );
 		int count = 0;
-		for(Node n: longTree){
+		for( Relationship r: longTree){
 			count++;
 		}
 		assertTrue( count == 39);
@@ -254,12 +249,13 @@ public class TestSortedTree extends Neo4jTestCase
 		
 		assertTrue( stringTree.iterator().hasNext() );
 		count = 0;
-		for(Node n: stringTree){
+		for(Relationship r: stringTree){
 			count++;
 		}
 		assertTrue( count == 39);		
 		count = 0;
-		for(Node n: stringTree){
+		for(Relationship r: stringTree){
+            Node n = r.getEndNode();
 			count++;
 			if(count == 1){
 				assertTrue(n.getProperty("name").equals("nodeaaaaa"));
@@ -291,7 +287,7 @@ public class TestSortedTree extends Neo4jTestCase
 		stringTree.removeNode(node36);
 		stringTree.removeNode(node38);
 		count = 0;
-		for(Node n: stringTree){
+		for(Relationship r: stringTree){
 			count++;
 		}
 		assertTrue( count == 20);
@@ -317,7 +313,7 @@ public class TestSortedTree extends Neo4jTestCase
 		stringTree.removeNode(node37);
 		stringTree.removeNode(node39);
 		count = 0;
-		for(Node n: stringTree){
+		for(Relationship r: stringTree){
 			count++;
 		}
 		assertTrue( count == 0);		


### PR DESCRIPTION
Allow IndexedRelationshipExpander to expand relationships from the key value end of the IndexedRelationship.

A number of issues were found while implementing this including:
- exceptions thrown when multiple IR's contained a key value relationship to the same node
- start and end nodes were transposed when incoming relationships were handled by IR

In discussions with Niels Hoogeveen it was decided that the best way of a solution for multiple IR's having key value relationships to the same node was for SortedTree to return an iterator over Relationships rather than Nodes.

Since this changes a few API's this may need a bit of a review before accepting.
