### PR TITLE
Added locks and tests for concurrency for UnrolledLinkedList

### DIFF
--- a/src/test/java/org/neo4j/collections/list/TestUnrolledLinkedList.java
+++ b/src/test/java/org/neo4j/collections/list/TestUnrolledLinkedList.java
@@ -20,22 +20,16 @@
 package org.neo4j.collections.list;
 
 import org.junit.Test;
-import org.neo4j.collections.GraphCollection;
-import org.neo4j.collections.Neo4jTestCase;
 import org.neo4j.collections.NodeCollectionLoader;
-import org.neo4j.graphdb.Direction;
-import org.neo4j.graphdb.DynamicRelationshipType;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Iterator;
 
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertNotNull;
-import static junit.framework.Assert.assertTrue;
 
 /**
  * The normal order of adding to an UnrolledLinkedList would be in the end of the list forwards order, e.g. adding
@@ -43,24 +37,8 @@ import static junit.framework.Assert.assertTrue;
  * reverses the order of the nodes after sorting by the comparator, and why the adding in reverse test reverses it again
  * therefore actually adding the items in order.
  */
-public class TestUnrolledLinkedList extends Neo4jTestCase
+public class TestUnrolledLinkedList extends UnrolledLinkedListTestCase
 {
-    public static class IdComparator implements java.util.Comparator<Node>
-    {
-        public int compare( Node n1, Node n2 )
-        {
-            return ((Long) n1.getId()).compareTo( n2.getId() );
-        }
-    }
-
-    public static class EqualComparator implements java.util.Comparator<Node>
-    {
-        public int compare( Node n1, Node n2 )
-        {
-            return 0;
-        }
-    }
-
     @Test
     public void testCreationAndRecreating()
     {
@@ -409,79 +387,5 @@ public class TestUnrolledLinkedList extends Neo4jTestCase
             assertEquals( nodes.get( count++ ), relationship.getEndNode() );
         }
         assertEquals( nodes.size(), count );
-    }
-
-    private void checkPageCount( Node baseNode, int min, int max )
-    {
-        int count = 1;
-        Node node = baseNode.getSingleRelationship(
-            DynamicRelationshipType.withName( "HEAD" ), Direction.OUTGOING ).getEndNode();
-        while ( node.hasRelationship( DynamicRelationshipType.withName( "NEXT_PAGE" ), Direction.OUTGOING ) )
-        {
-            count++;
-            node = node.getSingleRelationship(
-                DynamicRelationshipType.withName( "NEXT_PAGE" ), Direction.OUTGOING ).getEndNode();
-        }
-
-        assertTrue( "Page count should be greater than or equal to " + min + " was " + count, count >= min );
-        assertTrue( "Page count should be less than or equal to " + max + " was " + count, count <= max );
-    }
-
-    private void checkItemCounts( Node baseNode )
-    {
-        Node page = baseNode.getSingleRelationship(
-            DynamicRelationshipType.withName( "HEAD" ), Direction.OUTGOING ).getEndNode();
-        do
-        {
-            Integer count = 0;
-            for ( Relationship relationship : page.getRelationships(
-                GraphCollection.RelationshipTypes.VALUE, Direction.OUTGOING ) )
-            {
-                count++;
-            }
-            assertTrue( page.hasProperty( UnrolledLinkedList.ITEM_COUNT ) );
-            assertEquals( count, page.getProperty( UnrolledLinkedList.ITEM_COUNT ) );
-
-            Relationship next = page.getSingleRelationship(
-                DynamicRelationshipType.withName( "NEXT_PAGE" ), Direction.OUTGOING );
-            if ( next != null )
-            {
-                page = next.getEndNode();
-            }
-            else
-            {
-                page = null;
-            }
-        }
-        while ( page != null );
-    }
-
-    private void removeNodes( ArrayList<Node> nodes, UnrolledLinkedList list, int removalCount )
-    {
-        int count = 0;
-        for ( Iterator<Node> nodeIterator = nodes.iterator(); nodeIterator.hasNext(); )
-        {
-            Node node = nodeIterator.next();
-            assertTrue( list.remove( node ) );
-            nodeIterator.remove();
-
-            count++;
-            if ( count == removalCount )
-            {
-                return;
-            }
-        }
-    }
-
-    private ArrayList<Node> createNodes( int count )
-    {
-        ArrayList<Node> nodes = new ArrayList<Node>();
-        for ( int i = 0; i < count; i++ )
-        {
-            nodes.add( graphDb().createNode() );
-        }
-        Collections.sort( nodes, new IdComparator() );
-        Collections.reverse( nodes );
-        return nodes;
     }
 }

--- a/src/test/java/org/neo4j/collections/list/TestUnrolledLinkedListConcurrency.java
+++ b/src/test/java/org/neo4j/collections/list/TestUnrolledLinkedListConcurrency.java
@@ -1,0 +1,322 @@
+/**
+ * Copyright (c) 2002-2011 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.collections.list;
+
+import org.junit.Test;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Transaction;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertTrue;
+
+public class TestUnrolledLinkedListConcurrency extends UnrolledLinkedListTestCase
+{
+    private enum Signals
+    {
+        WRITE, READ
+    }
+
+    private ExecutorService executorService = Executors.newSingleThreadExecutor();
+
+    @Test
+    public void testAddInSamePageHavingReadPastWithReadTransaction() throws Exception
+    {
+        final ArrayList<Node> nodes = createNodes( 4 );
+        final UnrolledLinkedList list = new UnrolledLinkedList( graphDb(), new IdComparator(), 4 );
+        final SignalSynchronizer sync = new SignalSynchronizer( Signals.class );
+
+        FutureTask<Boolean> reader = new ThrowingFutureTask<Boolean>( new Callable<Boolean>()
+        {
+            @Override
+            public Boolean call() throws Exception
+            {
+                Transaction tx = graphDb().beginTx();
+                try
+                {
+                    ArrayList<Node> innerNodes = new ArrayList<Node>( nodes.subList( 0, 3 ) );
+                    Collections.reverse( innerNodes );
+                    assertTrue( sync.wait( Signals.READ ) );
+                    UnrolledLinkedList innerList = new UnrolledLinkedList( list.getBaseNode() );
+
+                    int count = 0;
+                    for ( Node node : innerList )
+                    {
+                        assertEquals( innerNodes.get( count ), node );
+                        if ( ++count == 2 )
+                        {
+                            // wont receive read signal as writer will be waiting to gain a write lock on base node
+                            // will timeout then finish its reading process, whereby the writer will gain write lock
+                            // and complete its write process
+                            assertFalse( sync.signalAndWait( Signals.WRITE, Signals.READ, 1, TimeUnit.SECONDS ) );
+                        }
+                    }
+
+                    tx.success();
+                    return true;
+                }
+                finally
+                {
+                    tx.finish();
+                }
+            }
+        } );
+        executorService.execute( reader );
+
+        int count = 0;
+        for ( Node node : nodes )
+        {
+            list.addNode( node );
+            if ( ++count == 3 )
+            {
+                // commits the nodes added through by the writer so the reader can then see them
+                // also releases the write lock held on base node allowing reader thread access
+                restartTx();
+                assertTrue( sync.signalAndWait( Signals.READ, Signals.WRITE ) );
+            }
+        }
+        restartTx();
+        sync.signal( Signals.READ );
+
+        assertTrue( reader.get( 1000, TimeUnit.MILLISECONDS ) );
+    }
+
+    @Test
+    public void testAddInSamePageHavingReadPastWithoutReadTransaction() throws Exception
+    {
+        final ArrayList<Node> nodes = createNodes( 4 );
+        final UnrolledLinkedList list = new UnrolledLinkedList( graphDb(), new IdComparator(), 4 );
+        final SignalSynchronizer sync = new SignalSynchronizer( Signals.class );
+
+        FutureTask<Boolean> reader = new ThrowingFutureTask<Boolean>( new Callable<Boolean>()
+        {
+            @Override
+            public Boolean call() throws Exception
+            {
+                ArrayList<Node> innerNodes = new ArrayList<Node>( nodes.subList( 0, 3 ) );
+                Collections.reverse( innerNodes );
+                assertTrue( sync.wait( Signals.READ ) );
+                UnrolledLinkedList innerList = new UnrolledLinkedList( list.getBaseNode() );
+
+                int count = 0;
+                for ( Node node : innerList )
+                {
+                    assertEquals( innerNodes.get( count ), node );
+                    if ( ++count == 2 )
+                    {
+                        // will receive read signal as there will be no read lock against the base node therefore
+                        // the writer add node will not block
+                        assertTrue( sync.signalAndWait( Signals.WRITE, Signals.READ, 1, TimeUnit.SECONDS ) );
+                    }
+                }
+
+                return true;
+            }
+        } );
+        executorService.execute( reader );
+
+        int count = 0;
+        for ( Node node : nodes )
+        {
+            list.addNode( node );
+            if ( ++count == 3 )
+            {
+                // commits the nodes added through by the writer so the reader can then see them
+                // also releases the write lock held on base node allowing reader thread access
+                restartTx();
+                assertTrue( sync.signalAndWait( Signals.READ, Signals.WRITE ) );
+            }
+        }
+        restartTx();
+        sync.signal( Signals.READ );
+
+        assertTrue( reader.get( 1000, TimeUnit.MILLISECONDS ) );
+    }
+
+    private static class SignalSynchronizer
+    {
+        private static final long MAX_WAIT_SECONDS = 10;
+        private final Lock lock;
+        private final Map<Enum, Condition> conditions;
+
+        public SignalSynchronizer( Class<? extends Enum> signals )
+        {
+            lock = new ReentrantLock();
+            conditions = new HashMap<Enum, Condition>();
+
+            for ( Enum signal : signals.getEnumConstants() )
+            {
+                conditions.put( signal, lock.newCondition() );
+            }
+        }
+
+        public boolean wait( Enum waitSignal, long timeout, TimeUnit unit ) throws InterruptedException
+        {
+            if ( !conditions.containsKey( waitSignal ) )
+            {
+                throw new IllegalArgumentException( "Not a valid signal: " + waitSignal );
+            }
+
+            lock.lock();
+            try
+            {
+                return conditions.get( waitSignal ).await( timeout, unit );
+            }
+            finally
+            {
+                lock.unlock();
+            }
+        }
+
+        public boolean wait( Enum waitSignal ) throws InterruptedException
+        {
+            if ( !conditions.containsKey( waitSignal ) )
+            {
+                throw new IllegalArgumentException( "Not a valid signal: " + waitSignal );
+            }
+
+            lock.lock();
+            try
+            {
+                return conditions.get( waitSignal ).await( MAX_WAIT_SECONDS, TimeUnit.SECONDS );
+            }
+            finally
+            {
+                lock.unlock();
+            }
+        }
+
+        public boolean signalAndWait( Enum signal, Enum waitSignal, long timeout, TimeUnit unit )
+            throws InterruptedException
+        {
+            if ( !conditions.containsKey( signal ) )
+            {
+                throw new IllegalArgumentException( "Not a valid signal: " + signal );
+            }
+            if ( !conditions.containsKey( waitSignal ) )
+            {
+                throw new IllegalArgumentException( "Not a valid signal: " + waitSignal );
+            }
+
+            lock.lock();
+            try
+            {
+                conditions.get( signal ).signal();
+                return conditions.get( waitSignal ).await( timeout, unit );
+            }
+            finally
+            {
+                lock.unlock();
+            }
+        }
+
+        public boolean signalAndWait( Enum signal, Enum waitSignal ) throws InterruptedException
+        {
+            if ( !conditions.containsKey( signal ) )
+            {
+                throw new IllegalArgumentException( "Not a valid signal: " + signal );
+            }
+            if ( !conditions.containsKey( waitSignal ) )
+            {
+                throw new IllegalArgumentException( "Not a valid signal: " + waitSignal );
+            }
+
+            lock.lock();
+            try
+            {
+                conditions.get( signal ).signal();
+                return conditions.get( waitSignal ).await( MAX_WAIT_SECONDS, TimeUnit.SECONDS );
+            }
+            finally
+            {
+                lock.unlock();
+            }
+        }
+
+        public void signal( Enum signal )
+        {
+            if ( !conditions.containsKey( signal ) )
+            {
+                throw new IllegalArgumentException( "Not a valid signal: " + signal );
+            }
+
+            lock.lock();
+            try
+            {
+                conditions.get( signal ).signal();
+            }
+            finally
+            {
+                lock.unlock();
+            }
+        }
+    }
+
+    private static class ThrowingFutureTask<V> extends FutureTask<V>
+    {
+        public ThrowingFutureTask( Callable<V> callable )
+        {
+            super( callable );
+        }
+
+        @Override
+        protected void done()
+        {
+            super.done();
+            try
+            {
+                if ( !isCancelled() )
+                {
+                    get();
+                }
+            }
+            catch ( ExecutionException e )
+            {
+                Throwable cause = e.getCause();
+                if ( cause instanceof RuntimeException )
+                {
+                    throw (RuntimeException) cause;
+                }
+                if ( cause instanceof Error )
+                {
+                    throw (Error) cause;
+                }
+            }
+            catch ( InterruptedException e )
+            {
+                throw new AssertionError( e );
+            }
+        }
+    }
+}

--- a/src/test/java/org/neo4j/collections/list/UnrolledLinkedListTestCase.java
+++ b/src/test/java/org/neo4j/collections/list/UnrolledLinkedListTestCase.java
@@ -1,0 +1,131 @@
+/**
+ * Copyright (c) 2002-2011 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.collections.list;
+
+import org.neo4j.collections.GraphCollection;
+import org.neo4j.collections.Neo4jTestCase;
+import org.neo4j.graphdb.Direction;
+import org.neo4j.graphdb.DynamicRelationshipType;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Relationship;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertTrue;
+
+/**
+ * @author Bryce Ewing
+ * @version 0.1
+ */
+public class UnrolledLinkedListTestCase extends Neo4jTestCase
+{
+    protected void checkPageCount( Node baseNode, int min, int max )
+    {
+        int count = 1;
+        Node node = baseNode.getSingleRelationship(
+            DynamicRelationshipType.withName( "HEAD" ), Direction.OUTGOING ).getEndNode();
+        while ( node.hasRelationship( DynamicRelationshipType.withName( "NEXT_PAGE" ), Direction.OUTGOING ) )
+        {
+            count++;
+            node = node.getSingleRelationship(
+                DynamicRelationshipType.withName( "NEXT_PAGE" ), Direction.OUTGOING ).getEndNode();
+        }
+
+        assertTrue( "Page count should be greater than or equal to " + min + " was " + count, count >= min );
+        assertTrue( "Page count should be less than or equal to " + max + " was " + count, count <= max );
+    }
+
+    protected void checkItemCounts( Node baseNode )
+    {
+        Node page = baseNode.getSingleRelationship(
+            DynamicRelationshipType.withName( "HEAD" ), Direction.OUTGOING ).getEndNode();
+        do
+        {
+            Integer count = 0;
+            for ( Relationship relationship : page.getRelationships(
+                GraphCollection.RelationshipTypes.VALUE, Direction.OUTGOING ) )
+            {
+                count++;
+            }
+            assertTrue( page.hasProperty( UnrolledLinkedList.ITEM_COUNT ) );
+            assertEquals( count, page.getProperty( UnrolledLinkedList.ITEM_COUNT ) );
+
+            Relationship next = page.getSingleRelationship(
+                DynamicRelationshipType.withName( "NEXT_PAGE" ), Direction.OUTGOING );
+            if ( next != null )
+            {
+                page = next.getEndNode();
+            }
+            else
+            {
+                page = null;
+            }
+        }
+        while ( page != null );
+    }
+
+    protected void removeNodes( ArrayList<Node> nodes, UnrolledLinkedList list, int removalCount )
+    {
+        int count = 0;
+        for ( Iterator<Node> nodeIterator = nodes.iterator(); nodeIterator.hasNext(); )
+        {
+            Node node = nodeIterator.next();
+            assertTrue( list.remove( node ) );
+            nodeIterator.remove();
+
+            count++;
+            if ( count == removalCount )
+            {
+                return;
+            }
+        }
+    }
+
+    protected ArrayList<Node> createNodes( int count )
+    {
+        ArrayList<Node> nodes = new ArrayList<Node>();
+        for ( int i = 0; i < count; i++ )
+        {
+            nodes.add( graphDb().createNode() );
+        }
+        Collections.sort( nodes, new IdComparator() );
+        Collections.reverse( nodes );
+        return nodes;
+    }
+
+    public static class IdComparator implements java.util.Comparator<Node>
+    {
+        public int compare( Node n1, Node n2 )
+        {
+            return ((Long) n1.getId()).compareTo( n2.getId() );
+        }
+    }
+
+    public static class EqualComparator implements java.util.Comparator<Node>
+    {
+        public int compare( Node n1, Node n2 )
+        {
+            return 0;
+        }
+    }
+}


### PR DESCRIPTION
Write locks now acquired for add node, remove node, read locks now acquired for interators.

There is a helper concurrency class that is currently an inner class on TestUnrolledLinkedListConcurrency that might be of interest to others too.  Not sure if there is something out there that does this already, had a search but didn't particularly find anything.  It takes an enum and allows different threads to both send signals and wait on signals.  In my case I am using it to send signals between a writer thread and a reader thread to tell them when to start reading or writing.
