### PR TITLE
Fixes NPE in RTreeIndex#remove

### DIFF
--- a/src/main/java/org/neo4j/collections/rtree/RTreeIndex.java
+++ b/src/main/java/org/neo4j/collections/rtree/RTreeIndex.java
@@ -108,6 +108,8 @@ public class RTreeIndex implements SpatialIndexWriter {
 		
 		// be sure geomNode is inside this RTree
 		Node indexNode = findLeafContainingGeometryNode(geomNode, throwExceptionIfNotFound);
+		if (indexNode == null) return;
+		
 		// remove the entry 
         final Relationship geometryRtreeReference = geomNode.getSingleRelationship(RTreeRelationshipTypes.RTREE_REFERENCE, Direction.INCOMING);
         if (geometryRtreeReference != null) {


### PR DESCRIPTION
When a node is being removed from an RTreeIndex (f.e. used in spatial), there was no NP check if the node was in the db but not in the index. This commit should fix it.

To make the 'illegal stuff' timeline tests work, they are decoupled now from the top-level transaction.
